### PR TITLE
Switch to modular boost from github

### DIFF
--- a/build-boost.sh
+++ b/build-boost.sh
@@ -18,13 +18,49 @@ DIR_SRC=${SOURCE_ROOT}/boost
 DIR_INSTALL=${INSTALL_ROOT}/boost
 FILE_MODULE=${INSTALL_ROOT}/modules/boost/${BOOST_VERSION}-${BOOST_BUILD_TYPE}
 
-DOWNLOAD_URL="http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2"
+#DOWNLOAD_URL="http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2"
 
 if [[ ! -d ${DIR_SRC} ]]; then
     (
-        mkdir -p ${DIR_SRC}
-        cd ${DIR_SRC}
-        wget -O- ${DOWNLOAD_URL} | tar xj --strip-components=1
+        # Get from sourceforge
+        #mkdir -p ${DIR_SRC}
+        #cd ${DIR_SRC}
+	# When using the sourceforge link
+        #wget -O- ${DOWNLOAD_URL} | tar xj --strip-components=1
+
+	# Get super repository variant 1 (get entire super project)
+	#cd ${SOURCE_ROOT}
+	#git clone https://github.com/boostorg/boost boost
+	#cd boost
+	# Get correct version before getting the submodules
+	#git checkout boost-${BOOST_VERSION}
+	# NOTE: Rerun all submodule inits when switchting the version using this variant...
+
+	# Get super repository variant 2 (get only the correct commit)
+	cd ${SOURCE_ROOT}
+	git clone --depth 1 --branch boost-${BOOST_VERSION} https://github.com/boostorg/boost boost
+
+	cd boost
+	# checkout required tools
+	git submodule update --init --recursive --depth=1 tools/build/
+	git submodule update --init --recursive --depth=1 tools/boost_install/
+	# checkout basic lib submodules
+	git submodule update --init --recursive --depth=1 libs/headers/
+	git submodule update --init --recursive --depth=1 libs/config/
+	git submodule update --init --recursive --depth=1 libs/io/
+	# checkout actual compoments that we want
+	git submodule update --init --recursive --depth=1 libs/thread/
+	git submodule update --init --recursive --depth=1 libs/iostreams/
+	git submodule update --init --recursive --depth=1 libs/date_time/
+	git submodule update --init --recursive --depth=1 libs/chrono/
+	git submodule update --init --recursive --depth=1 libs/system/
+	git submodule update --init --recursive --depth=1 libs/regex/
+	git submodule update --init --recursive --depth=1 libs/program_options/
+	git submodule update --init --recursive --depth=1 libs/filesystem/
+	git submodule update --init --recursive --depth=1 libs/atomic/
+	git submodule update --init --recursive --depth=1 libs/spirit/
+	# Adapt as needed for other stuff
+
         echo "using gcc : : $CXX ; " >tools/build/src/user-config.jam
     )
 fi


### PR DESCRIPTION
As there have been some issues with the current Boost download link (sourceforge being down), this PR switches the boost download to Github (using modular boost).